### PR TITLE
Improve robustness of initialising Metrics

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
         long_description = fh.read()
 
     setuptools.setup(
-        version='1.4.1',  # also update version in metrics.py -> version
+        version='1.4.2',  # also update version in metrics.py -> version
         author_email='Joeran.Bosma@radboudumc.nl',
         long_description=long_description,
         long_description_content_type="text/markdown",

--- a/src/picai_eval/metrics.py
+++ b/src/picai_eval/metrics.py
@@ -51,14 +51,14 @@ class Metrics:
         if self.case_target is None:
             # derive case-level targets as the maximum lesion-level target
             self.case_target = {
-                idx: max([is_lesion for is_lesion, _, _ in case_y_list])
+                idx: max([is_lesion for is_lesion, _, _ in case_y_list]) if len(case_y_list) else 0
                 for idx, case_y_list in self.lesion_results.items()
             }
 
         if self.case_pred is None:
             # derive case-level predictions as the maximum lesion-level prediction
             self.case_pred = {
-                idx: max([confidence for _, confidence, _ in case_y_list])
+                idx: max([confidence for _, confidence, _ in case_y_list]) if len(case_y_list) else 0
                 for idx, case_y_list in self.lesion_results.items()
             }
 


### PR DESCRIPTION
If no lesion candidates nor ground truth lesions are present, the `y_list` can be an empty list. In those cases, there are no predictions, so the `case_pred` should be `0`. Also, because there are no gt lesions, `case_target` should be `0`.