### PR TITLE
Change image_utils.py to work with nnunetv2 predictions and ground truth labels with multi-class segmentations.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.8', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,10 +8,10 @@ platforms = unix, linux, osx, cygwin, win32
 classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 [options]
 packages =

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
         long_description = fh.read()
 
     setuptools.setup(
-        version='1.4.5',  # also update version in metrics.py -> version
+        version='1.4.6',  # also update version in metrics.py -> version
         author_email='Joeran.Bosma@radboudumc.nl',
         long_description=long_description,
         long_description_content_type="text/markdown",

--- a/src/picai_eval/image_utils.py
+++ b/src/picai_eval/image_utils.py
@@ -69,7 +69,7 @@ def read_image(path: PathLike):
     elif '.nii' in path or '.mha' in path or 'mhd' in path:
         return sitk.GetArrayFromImage(sitk.ReadImage(path))
     elif '.npz' in path:
-        #read the nnU-Net format
+        # read the nnU-Net format
         data = np.load(path)
         data = data["softmax"] if "softmax" in data else data["probabilities"]
         return data.astype("float32")[1]    

--- a/src/picai_eval/image_utils.py
+++ b/src/picai_eval/image_utils.py
@@ -69,10 +69,10 @@ def read_image(path: PathLike):
     elif '.nii' in path or '.mha' in path or 'mhd' in path:
         return sitk.GetArrayFromImage(sitk.ReadImage(path))
     elif '.npz' in path:
-        try:
-            return np.load(path)['softmax'].astype('float32')[1]  # nnUnet format
-        except Exception as e:
-            return np.load(path)['probabilities'].astype('float32')[1]  # nnUnet format
+    # read the nnU-Net format
+        data = np.load(path)
+        data = data["softmax"] if "softmax" in data else data["probabilities"]
+        return data.astype("float32")[1]    
     else:
         raise ValueError(f"Unexpected file path. Supported file formats: .nii(.gz), .mha, .npy and .npz. Got: {path}.")
 
@@ -88,5 +88,4 @@ def read_label(path: PathLike) -> "npt.NDArray[np.int32]":
     """Read label, given a filepath"""
     # read label and ensure correct dtype
     lbl: "npt.NDArray[np.int32]" = np.array(read_image(path), dtype=np.int32)
-    lbl[lbl != 1] = 0
     return lbl

--- a/src/picai_eval/image_utils.py
+++ b/src/picai_eval/image_utils.py
@@ -71,7 +71,7 @@ def read_image(path: PathLike):
     elif '.npz' in path:
         try:
             return np.load(path)['softmax'].astype('float32')[1]  # nnUnet format
-        except:
+        except Exception as e:
             return np.load(path)['probabilities'].astype('float32')[1]  # nnUnet format
     else:
         raise ValueError(f"Unexpected file path. Supported file formats: .nii(.gz), .mha, .npy and .npz. Got: {path}.")
@@ -88,5 +88,5 @@ def read_label(path: PathLike) -> "npt.NDArray[np.int32]":
     """Read label, given a filepath"""
     # read label and ensure correct dtype
     lbl: "npt.NDArray[np.int32]" = np.array(read_image(path), dtype=np.int32)
-    lbl[lbl!=1]=0
+    lbl[lbl != 1] = 0
     return lbl

--- a/src/picai_eval/image_utils.py
+++ b/src/picai_eval/image_utils.py
@@ -64,12 +64,15 @@ def read_image(path: PathLike):
     else:
         assert isinstance(path, str), f"Unexpected path type: {type(path)}. Please provide a Path or str."
 
-    if '.npz' in path:
-        return np.load(path)['probabilities'].astype('float32')[1]  # nnUnet format
-    elif '.npy' in path:
+    if '.npy' in path:
         return np.load(path)
     elif '.nii' in path or '.mha' in path or 'mhd' in path:
         return sitk.GetArrayFromImage(sitk.ReadImage(path))
+    elif '.npz' in path:
+        try:
+            return np.load(path)['softmax'].astype('float32')[1]  # nnUnet format
+        except:
+            return np.load(path)['probabilities'].astype('float32')[1]  # nnUnet format
     else:
         raise ValueError(f"Unexpected file path. Supported file formats: .nii(.gz), .mha, .npy and .npz. Got: {path}.")
 

--- a/src/picai_eval/image_utils.py
+++ b/src/picai_eval/image_utils.py
@@ -72,7 +72,7 @@ def read_image(path: PathLike):
         # read the nnU-Net format
         data = np.load(path)
         data = data["softmax"] if "softmax" in data else data["probabilities"]
-        return data.astype("float32")[1]    
+        return data.astype("float32")[1]
     else:
         raise ValueError(f"Unexpected file path. Supported file formats: .nii(.gz), .mha, .npy and .npz. Got: {path}.")
 

--- a/src/picai_eval/image_utils.py
+++ b/src/picai_eval/image_utils.py
@@ -64,12 +64,12 @@ def read_image(path: PathLike):
     else:
         assert isinstance(path, str), f"Unexpected path type: {type(path)}. Please provide a Path or str."
 
-    if '.npy' in path:
+    if '.npz' in path:
+        return np.load(path)['probabilities'].astype('float32')[1]  # nnUnet format
+    elif '.npy' in path:
         return np.load(path)
     elif '.nii' in path or '.mha' in path or 'mhd' in path:
         return sitk.GetArrayFromImage(sitk.ReadImage(path))
-    elif '.npz' in path:
-        return np.load(path)['softmax'].astype('float32')[1]  # nnUnet format
     else:
         raise ValueError(f"Unexpected file path. Supported file formats: .nii(.gz), .mha, .npy and .npz. Got: {path}.")
 
@@ -85,4 +85,5 @@ def read_label(path: PathLike) -> "npt.NDArray[np.int32]":
     """Read label, given a filepath"""
     # read label and ensure correct dtype
     lbl: "npt.NDArray[np.int32]" = np.array(read_image(path), dtype=np.int32)
+    lbl[lbl!=1]=0
     return lbl

--- a/src/picai_eval/image_utils.py
+++ b/src/picai_eval/image_utils.py
@@ -69,7 +69,7 @@ def read_image(path: PathLike):
     elif '.nii' in path or '.mha' in path or 'mhd' in path:
         return sitk.GetArrayFromImage(sitk.ReadImage(path))
     elif '.npz' in path:
-    # read the nnU-Net format
+        #read the nnU-Net format
         data = np.load(path)
         data = data["softmax"] if "softmax" in data else data["probabilities"]
         return data.astype("float32")[1]    


### PR DESCRIPTION
The framework accepts .npz predictions with the "probabilities" key as produced by nnunetv2.
The framework accepts ground truth labels with multi-class segmentations and assumes that the lesion segmentations correspond to label=1.