### PR TITLE
Bugfix `lesion_TPR_at_FPR`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
         long_description = fh.read()
 
     setuptools.setup(
-        version='1.4.7',  # also update version in metrics.py -> version
+        version='1.4.8',  # also update version in metrics.py -> version
         author_email='Joeran.Bosma@radboudumc.nl',
         long_description=long_description,
         long_description_content_type="text/markdown",

--- a/src/picai_eval/metrics.py
+++ b/src/picai_eval/metrics.py
@@ -121,7 +121,7 @@ class Metrics:
     def lesion_TPR_at_FPR(self, FPR: float) -> float:
         """Calculate the lesion-level true positive rate (sensitivity) at a given
         false positive rate (average number of false positives per examimation)"""
-        if np.max(self.lesion_FPR) < FPR:
+        if np.min(self.lesion_FPR) > FPR:
             return 0
         return self.lesion_TPR[self.lesion_FPR <= FPR][-1]
 

--- a/tests/test_lesion_tpr_at_fpr.py
+++ b/tests/test_lesion_tpr_at_fpr.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from picai_eval import Metrics
+
+
+def test_lesion_tpr_at_fpr():
+    """
+    Test the lesion TPR at FPR function
+    """
+    lesion_results = {
+        "0": [(0, 1, 1.)],
+        "1": [(0, 2, 1.)],
+        "2": [(1, 3, 1.)],
+        "3": [(1, 1, 1.), (1, 1, 1.)],
+        "4": [(0, 3, 1.)],
+        "5": [(1, 2.5, 1.), (1, 1.5, 1.)],
+    }
+    metrics = Metrics(lesion_results=lesion_results)
+    np.testing.assert_allclose(metrics.lesion_TPR, [0.2, 0.4, 0.4, 0.6, 0.6])
+    np.testing.assert_allclose(metrics.lesion_FPR, [0.16666667, 0.16666667, 0.33333334, 0.33333334, np.inf])
+
+    # test with FPR = 0.3
+    np.testing.assert_almost_equal(metrics.lesion_TPR_at_FPR(0.3), 0.4)
+
+    # test with too low FPR
+    np.testing.assert_almost_equal(metrics.lesion_TPR_at_FPR(0.1), 0.0)
+
+
+if __name__ == "__main__":
+    test_lesion_tpr_at_fpr()


### PR DESCRIPTION
The `lesion_TPR_at_FPR` function threw an error when a too-low FPR was requested. Now the function will return a TPR of 0 when the minimum operating point FPR is higher than the requested value.