### PR TITLE
Allow evaluating with no lesion candidates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
         long_description = fh.read()
 
     setuptools.setup(
-        version='1.4.9',  # also update version in metrics.py -> version
+        version='1.4.10',  # also update version in metrics.py -> version
         author_email='Joeran.Bosma@radboudumc.nl',
         long_description=long_description,
         long_description_content_type="text/markdown",

--- a/src/picai_eval/metrics.py
+++ b/src/picai_eval/metrics.py
@@ -247,8 +247,13 @@ class Metrics:
             TP[i] = tp
 
         # extend curve to infinity
-        TP[-1] = TP[-2]
-        FP[-1] = np.inf
+        if len(TP) >= 2:
+            TP[-1] = TP[-2]
+            FP[-1] = np.inf
+        else:
+            # no lesions detected
+            TP = np.array([0, 0])
+            FP = np.array([0, np.inf])
 
         return {
             'TP': TP,

--- a/tests/Development-README.md
+++ b/tests/Development-README.md
@@ -29,5 +29,5 @@ AutoPEP8 for formatting (this can be done automatically on save, see e.g. https:
 # Push release to PyPI
 1. Increase version in setup.py, and set below
 2. Build: `python -m build`
-3. Test package distribution: `python -m twine upload --repository testpypi dist/*1.4.9*`
-4. Distribute package to PyPI: `python -m twine upload dist/*1.4.9*`
+3. Test package distribution: `python -m twine upload --repository testpypi dist/*1.4.10*`
+4. Distribute package to PyPI: `python -m twine upload dist/*1.4.10*`

--- a/tests/test_calculate_counts.py
+++ b/tests/test_calculate_counts.py
@@ -1,0 +1,44 @@
+import numpy as np
+
+from picai_eval import Metrics
+
+
+def test_calculate_counts():
+    """
+    Test the lesion TPR and FPR function
+    """
+    lesion_results = {
+        "0": [(0, 0, 0.)],
+        "1": [(0, 0, 0.)],
+        "2": [(1, 1, 0.)],
+        "3": [(1, 0, 0.), (1, 0, 0.)],
+        "4": [(0, 0, 0.)],
+        "5": [(1, 0, 0.), (1, 0, 0.)],
+    }
+    metrics = Metrics(lesion_results=lesion_results)
+    np.testing.assert_allclose(metrics.lesion_TPR, [0.2, 0.2])
+    np.testing.assert_allclose(metrics.lesion_FPR, [0.0, np.inf])
+    assert metrics.AP == 0.2
+
+
+def test_calculate_counts_empty():
+    """
+    Test the lesion TPR and FPR function
+    """
+    lesion_results = {
+        "0": [(0, 0, 0.)],
+        "1": [(0, 0, 0.)],
+        "2": [(1, 0, 0.)],
+        "3": [(1, 0, 0.), (1, 0, 0.)],
+        "4": [(0, 0, 0.)],
+        "5": [(1, 0, 0.), (1, 0, 0.)],
+    }
+    metrics = Metrics(lesion_results=lesion_results)
+    np.testing.assert_allclose(metrics.lesion_TPR, [0., 0.0])
+    np.testing.assert_allclose(metrics.lesion_FPR, [0.0, np.inf])
+    assert metrics.AP == 0.0
+
+
+if __name__ == "__main__":
+    test_calculate_counts()
+    test_calculate_counts_empty()


### PR DESCRIPTION
In the previous implementation, having no lesion candidates broke the evaluation. Also added tests for having zero or one lesion candidate.